### PR TITLE
Limit the preview to only URL and file ends with JSON

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
 	"description": "Instantly transform raw JSON into a beautifully structured and color-coded format.",
 	"permissions": ["activeTab"],
 	"content_scripts": [{
-		"matches": ["<all_urls>"],
+		"matches": ["*://*.json*"],
 		"js": ["content.js"],
 		"css": ["styles.css"]
 	}],


### PR DESCRIPTION
Some generic CSS like `.content` is affecting websites like https://discover.buysellads.com/

Update the content script to run only when the path ends with `.json` as the extension.